### PR TITLE
More default targets for `Reflection Patch Target List`

### DIFF
--- a/src/main/java/com/cleanroommc/fugue/config/FugueConfig.java
+++ b/src/main/java/com/cleanroommc/fugue/config/FugueConfig.java
@@ -66,6 +66,10 @@ public class FugueConfig {
     )
     @Config.Name("Reflection Patch Target List")
     public static String[] reflectionPatchTargets = new String[] {
+            "com.fantasticsource.tools.ReflectionTool",
+            "lumien.custombackgrounds.CustomBackgrounds",
+            "com.fantasticsource.noadvancements.NoAdvancements",
+            "com.codetaylor.mc.athenaeum.util.Injector",
             "epicsquid.mysticallib.hax.Hax",
             "vazkii.quark.world.feature.TreeVariants",
             "vazkii.quark.base.handler.OverrideRegistryHandler",


### PR DESCRIPTION
This PR: 
- Adds reflection patch for Fantastic-Lib, CustomBackgrounds, NoAdvancements, and Athenaeum, so these mods, together with their dependents(e.g. Dropt), will not cause a crash. 

`com.fantasticsource.tools.ReflectionTool` is from Fantastic-Lib, and the origin of the other 3 classes should be obvious enough. 

I've tested this in Fantazy Tech modpack, and this change allows me to boot up successfully without crashing. 