### PR TITLE
default patch target++

### DIFF
--- a/src/main/java/com/cleanroommc/fugue/config/FugueConfig.java
+++ b/src/main/java/com/cleanroommc/fugue/config/FugueConfig.java
@@ -75,6 +75,8 @@ public class FugueConfig {
     )
     @Config.Name("Reflection Patch Target List")
     public static String[] reflectionPatchTargets = new String[] {
+            "quaternary.botaniatweaks.modules.botania.block.BotaniaRegistryReplacements",
+            "pl.asie.foamfix.client.deduplicator.Deduplicator",
             "com.fantasticsource.tools.ReflectionTool",
             "lumien.custombackgrounds.CustomBackgrounds",
             "com.fantasticsource.noadvancements.NoAdvancements",
@@ -117,6 +119,7 @@ public class FugueConfig {
     )
     @Config.Name("New Script Engine Patch Target List")
     public static String[] scriptEngineTargets = new String[] {
+            "nc.util.I18nHelper",
             "tk.zeitheron.solarflux.api.SolarScriptEngine",
             "com.github.tartaricacid.touhoulittlemaid.proxy.CommonProxy",
             "tk.zeitheron.expequiv.api.js.JSExpansion",


### PR DESCRIPTION
This PR: 
- Adds JS Engine patch for NuclearCraft, reflection patch for FoamFix and BotaniaTweaks. 

After this change, modpack Multiblock Madness should be able to boot up normally with Cleanroom installed(because that's what I used for testing). 