### PR TITLE
Fix refmaps, revert #51

### DIFF
--- a/src/main/java/com/cleanroommc/fugue/mixin/extrautils2/TransferNodeEnergyMixin.java
+++ b/src/main/java/com/cleanroommc/fugue/mixin/extrautils2/TransferNodeEnergyMixin.java
@@ -8,9 +8,9 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
-@Mixin(value = TransferNodeEnergy.class, remap = false)
+@Mixin(value = TransferNodeEnergy.class)
 public class TransferNodeEnergyMixin {
-    @Redirect(method = "update", at = @At(value = "INVOKE", target = "Lcom/google/common/util/concurrent/Futures;addCallback(Lcom/google/common/util/concurrent/ListenableFuture;Lcom/google/common/util/concurrent/FutureCallback;)V"))
+    @Redirect(method = "update", at = @At(value = "INVOKE", target = "Lcom/google/common/util/concurrent/Futures;addCallback(Lcom/google/common/util/concurrent/ListenableFuture;Lcom/google/common/util/concurrent/FutureCallback;)V", remap = false))
     private void redirectAddCallback(ListenableFuture future, FutureCallback callback) {
         Futures.addCallback(future, callback, Runnable::run);
     }

--- a/src/main/java/com/cleanroommc/fugue/mixin/extrautils2/XUBlockStatic$3Mixin.java
+++ b/src/main/java/com/cleanroommc/fugue/mixin/extrautils2/XUBlockStatic$3Mixin.java
@@ -1,61 +1,22 @@
 package com.cleanroommc.fugue.mixin.extrautils2;
 
-import com.rwtema.extrautils2.backend.XUBlock;
-import com.rwtema.extrautils2.backend.XUBlockStatic;
-import com.rwtema.extrautils2.backend.model.MutableModel;
-import com.rwtema.extrautils2.backend.model.PassthruModelBlock;
-import com.rwtema.extrautils2.backend.model.Transforms;
-import net.minecraft.block.state.IBlockState;
-import net.minecraft.client.renderer.block.model.BakedQuad;
-import net.minecraft.client.renderer.block.model.ModelResourceLocation;
-import net.minecraft.util.BlockRenderLayer;
-import net.minecraft.util.EnumFacing;
-import net.minecraftforge.client.MinecraftForgeClient;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
-import org.spongepowered.asm.mixin.*;
-
-import javax.annotation.Nonnull;
 import java.util.HashMap;
-import java.util.List;
+import java.util.function.Function;
 
-/**
- * @author ZZZank
- */
-@Mixin(targets = "com.rwtema.extrautils2.backend.XUBlockStatic$3", remap = false)
-public abstract class XUBlockStatic$3Mixin extends PassthruModelBlock {
-    @Shadow
-    @Final
-    XUBlockStatic this$0;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
-    @Shadow
-    HashMap<IBlockState, HashMap<EnumFacing, HashMap<BlockRenderLayer, List<BakedQuad>>>> cachedLists;
-
-    @Unique
-    private final Object fugue$lock = new Object();
-
-    private XUBlockStatic$3Mixin(XUBlock block, IBlockState key, ModelResourceLocation modelResourceLocation) {
-        super(block, key, modelResourceLocation);
-    }
-
-    /**
-     * @author ZZZank
-     * @reason original implementation forces the usage of {@link HashMap}, which is NOT concurrency-safe
-     */
-    @Overwrite
-    @Nonnull
-    @SideOnly(Side.CLIENT)
-    @Override
-    public List<BakedQuad> getQuads(IBlockState state, EnumFacing side, long rand) {
-        synchronized (fugue$lock) {
-            return cachedLists
-                .computeIfAbsent(state, XUBlockStatic::dummyCreateHash)
-                .computeIfAbsent(side, XUBlockStatic::dummyCreateHash)
-                .computeIfAbsent(MinecraftForgeClient.getRenderLayer(), (layer) -> {
-                    MutableModel model = new MutableModel(Transforms.blockTransforms);
-                    this$0.cachedModels.get(state).loadIntoMutable(model, layer);
-                    return model.getQuads(state, side, rand);
-                });
+@Mixin(targets = "com.rwtema.extrautils2.backend.XUBlockStatic$3")
+public class XUBlockStatic$3Mixin {
+    @Redirect(method = "getQuads", at = @At(value = "INVOKE", target = "Ljava/util/HashMap;computeIfAbsent(Ljava/lang/Object;Ljava/util/function/Function;)Ljava/lang/Object;", remap = false))
+    private Object hackCIA(HashMap instance, Object n, Function<Object, Object> k) {
+        if (instance.containsKey(n)) {
+            return instance.get(n);
+        } else {
+            Object v = k.apply(n);
+            instance.put(n, v);
+            return v;
         }
     }
 }

--- a/src/main/resources/fugue.mixin.mod.json
+++ b/src/main/resources/fugue.mixin.mod.json
@@ -2,7 +2,7 @@
   "required": true,
   "package": "com.cleanroommc.fugue.mixin",
   "compatibilityLevel": "JAVA_8",
-  "refmap": "fugue.mixin.refmap.json",
+  "refmap": "fugue.mixins.refmap.json",
   "target": "@env(MOD)",
   "plugin": "com.cleanroommc.fugue.common.FugueMixinConfigPlugin",
   "mixins": [


### PR DESCRIPTION
The buildscript was generating `fugue.mixins.refmap.json` ([here](https://github.com/CleanroomMC/Fugue/blob/master/build.gradle#L88)), but the mixin config had a typo (no "s" in "mixins") so the refmap failed to load. This only affected 2 EXU mixins (`TransferNodeEnergyMixin` and `XUBlockStatic$3Mixin`) that needed remapping, but could have affected any other mixin that needs remapping in the future. Those mixins also had `remap=false` incorrectly for `update` and `getQuads`, respectively, so fixed that. I tested in prod and the mixins now actually find their targets.

Reverts #51 back to original mixin, but with proper remapping. I think the original logic was correct, considering there are similar fixes for other mods.

