### PR TITLE
Make AR transformer compatible with fork version

### DIFF
--- a/src/main/java/com/cleanroommc/fugue/config/ModPatchConfig.java
+++ b/src/main/java/com/cleanroommc/fugue/config/ModPatchConfig.java
@@ -5,6 +5,10 @@ import net.minecraftforge.common.config.Config;
 public class ModPatchConfig {
     @Config.Name("Enable Ender Core Patch")
     public boolean enableEnderCore = true;
+    @Config.Comment({
+            "This patch is only for Advanced Rocketry by zmaster587.",
+            "Advanced Rocketry - Reworked by MarvinEckhardt doesn't need this!"
+    })
     @Config.Name("Enable Advanced Rocketry Patch")
     public boolean enableAR = true;
     @Config.Name("Enable Shoulder Surfing Reloaded Patch")


### PR DESCRIPTION
See dercodeKoenig/AdvancedRocketry#37 for details. Made the transformer more specific to original AR, which means you don't need to disable the patch in the configs to get AR-Reworked ASM code to work.
