### PR TITLE
Add Logistics Pipes NotFound

### DIFF
--- a/src/main/java/com/cleanroommc/fugue/config/LogisticsPipesPreloadConfig.java
+++ b/src/main/java/com/cleanroommc/fugue/config/LogisticsPipesPreloadConfig.java
@@ -29,5 +29,6 @@ public class LogisticsPipesPreloadConfig {
             "logisticspipes.network.packets.debuggui.DebugPanelOpen",
             "logisticspipes.network.packets.upgrade.SneakyUpgradeSidePacket",
             "logisticspipes.network.packets.hud.ChestContent",
+            "logisticspipes.network.packets.chassis.ChestGuiClosed",
     };
 }


### PR DESCRIPTION
The game crashed during startup. After checking the crash log, the following error was found:
java.lang.ClassNotFoundException: logisticspipes.network.packets.chassis.ChestGuiClosed
[crash-2024-12-10_21.23.06-client.txt](https://github.com/user-attachments/files/18080409/crash-2024-12-10_21.23.06-client.txt)
