### PR TITLE
Add Logistics Pipes NotFound

### DIFF
--- a/src/main/java/com/cleanroommc/fugue/config/LogisticsPipesPreloadConfig.java
+++ b/src/main/java/com/cleanroommc/fugue/config/LogisticsPipesPreloadConfig.java
@@ -30,5 +30,6 @@ public class LogisticsPipesPreloadConfig {
             "logisticspipes.network.packets.upgrade.SneakyUpgradeSidePacket",
             "logisticspipes.network.packets.hud.ChestContent",
             "logisticspipes.network.packets.chassis.ChestGuiClosed",
+            "logisticspipes.network.guis.LogisticsPlayerSettingsGuiProvider",
     };
 }

--- a/src/main/java/com/cleanroommc/fugue/config/LogisticsPipesPreloadConfig.java
+++ b/src/main/java/com/cleanroommc/fugue/config/LogisticsPipesPreloadConfig.java
@@ -31,5 +31,6 @@ public class LogisticsPipesPreloadConfig {
             "logisticspipes.network.packets.hud.ChestContent",
             "logisticspipes.network.packets.chassis.ChestGuiClosed",
             "logisticspipes.network.guis.LogisticsPlayerSettingsGuiProvider",
+            "logisticspipes.network.guis.EditChannelGuiProvider",
     };
 }


### PR DESCRIPTION
The game crashed during startup. After checking the crash log, the following error was found:
logisticspipes.network.guis.LogisticsPlayerSettingsGuiProvider
[crash-2024-12-12_18.13.10-client.txt](https://github.com/user-attachments/files/18110018/crash-2024-12-12_18.13.10-client.txt)
