### PR TITLE
Add Logistics Pipes NotFound

### DIFF
--- a/src/main/java/com/cleanroommc/fugue/config/LogisticsPipesPreloadConfig.java
+++ b/src/main/java/com/cleanroommc/fugue/config/LogisticsPipesPreloadConfig.java
@@ -32,5 +32,6 @@ public class LogisticsPipesPreloadConfig {
             "logisticspipes.network.packets.chassis.ChestGuiClosed",
             "logisticspipes.network.guis.LogisticsPlayerSettingsGuiProvider",
             "logisticspipes.network.guis.EditChannelGuiProvider",
+            "logisticspipes.network.packets.cpipe.CPipeSatelliteImport",
     };
 }


### PR DESCRIPTION
The game crashed during startup. After checking the crash log, the following error was found:
logisticspipes.network.packets.cpipe.CPipeSatelliteImport
[crash-2024-12-12_20.25.12-client.txt](https://github.com/user-attachments/files/18111626/crash-2024-12-12_20.25.12-client.txt)
