### PR TITLE
Add Patches for ScreenshotViewer

### DIFF
--- a/src/main/java/com/cleanroommc/fugue/common/TransformerHelper.java
+++ b/src/main/java/com/cleanroommc/fugue/common/TransformerHelper.java
@@ -50,6 +50,7 @@ import com.cleanroommc.fugue.transformer.openmodlib.InjectorMethodVisitorTransfo
 import com.cleanroommc.fugue.transformer.openmodlib.PlayerRendererHookVisitorTransformer;
 import com.cleanroommc.fugue.transformer.polyfrost.LaunchWrapperTweakerTransformer;
 import com.cleanroommc.fugue.transformer.replaymod.FuturesTransformer;
+import com.cleanroommc.fugue.transformer.screenshot_viewer.ScreenshotViewerTransformer;
 import com.cleanroommc.fugue.transformer.shouldersurfing.EntityPlayerRayTraceTransformer;
 import com.cleanroommc.fugue.transformer.simplehotspring.SimplyHotSpringsConfigTransformer;
 import com.cleanroommc.fugue.transformer.smoothfont.FontRendererTransformer;
@@ -485,6 +486,12 @@ public class TransformerHelper {
             TransformerDelegate.registerExplicitTransformer(
                     new MessageOpenHistoryTransformer(),
                     "de.maxhenkel.corpse.net.MessageOpenHistory"
+            );
+        }
+        if (FugueConfig.modPatchConfig.enableScreenshotViewer) {
+            TransformerDelegate.registerExplicitTransformer(
+                    new MessageOpenHistoryTransformerScreenshotViewerTransformer(),
+                    "io.github.lgatodu47.screenshot_viewer.ScreenshotViewer$ScreenshotViewerEvents"
             );
         }
 

--- a/src/main/java/com/cleanroommc/fugue/common/TransformerHelper.java
+++ b/src/main/java/com/cleanroommc/fugue/common/TransformerHelper.java
@@ -490,7 +490,7 @@ public class TransformerHelper {
         }
         if (FugueConfig.modPatchConfig.enableScreenshotViewer) {
             TransformerDelegate.registerExplicitTransformer(
-                    new MessageOpenHistoryTransformerScreenshotViewerTransformer(),
+                    new ScreenshotViewerTransformer(),
                     "io.github.lgatodu47.screenshot_viewer.ScreenshotViewer$ScreenshotViewerEvents"
             );
         }

--- a/src/main/java/com/cleanroommc/fugue/config/ModPatchConfig.java
+++ b/src/main/java/com/cleanroommc/fugue/config/ModPatchConfig.java
@@ -159,4 +159,6 @@ public class ModPatchConfig {
     public boolean enableTechgun = true;
     @Config.Name("Enable Corpse Patch")
     public boolean enableCorpse = true;
+    @Config.Name("Enable ScreenshotViewer Patch")
+    public boolean enableScreenshotViewer = true;
 }

--- a/src/main/java/com/cleanroommc/fugue/transformer/screenshot_viewer/ScreenshotViewerTransformer.java
+++ b/src/main/java/com/cleanroommc/fugue/transformer/screenshot_viewer/ScreenshotViewerTransformer.java
@@ -21,10 +21,12 @@ public class ScreenshotViewerTransformer implements IExplicitTransformer, Opcode
             // Overwrite -- Actual Redirect
             if ("onKeyInput".equals(method.name)) {
                 for (AbstractInsnNode node : method.instructions) {
-                    if ("getEventKeyState".equals(node.name)) {
-                        node.owner = "net/minecraft/client/settings/KeyBinding";
-                        node.name = "func_151468_f";
-                        method.instructions.insertBefore(node, new VarInsnNode(Opcodes.ALOAD, 3));
+                    if (node instanceof MethodInsnNode mi) {
+                        if ("getEventKeyState".equals(mi.name)) {
+                            mi.owner = "net/minecraft/client/settings/KeyBinding";
+                            mi.name = "func_151468_f";
+                            method.instructions.insertBefore(mi, new VarInsnNode(Opcodes.ALOAD, 3));
+                        }
                     }
                 }
 

--- a/src/main/java/com/cleanroommc/fugue/transformer/screenshot_viewer/ScreenshotViewerTransformer.java
+++ b/src/main/java/com/cleanroommc/fugue/transformer/screenshot_viewer/ScreenshotViewerTransformer.java
@@ -1,0 +1,44 @@
+package com.cleanroommc.fugue.transformer.screenshot_viewer;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.*;
+import top.outlands.foundation.IExplicitTransformer;
+
+//Target: [
+//      io.github.lgatodu47.screenshot_viewer.ScreenshotViewer$ScreenshotViewerEvents
+// ]
+public class ScreenshotViewerTransformer implements IExplicitTransformer, Opcodes {
+
+    @Override
+    public byte[] transform(byte[] bytes) {
+        var classReader = new ClassReader(bytes);
+        var classNode = new ClassNode();
+        classReader.accept(classNode, 0);
+
+        for (var method : classNode.methods) {
+            // Overwrite -- Actual Redirect
+            if ("onKeyInput".equals(method.name)) {
+                for (AbstractInsnNode node : method.instructions) {
+                    if ("getEventKeyState".equals(node.name)) {
+                        node.owner = "net/minecraft/client/settings/KeyBinding";
+                        node.name = "func_151468_f";
+                        method.instructions.insertBefore(node, new VarInsnNode(Opcodes.ALOAD, 3));
+                    }
+                }
+
+            }
+
+        }
+
+        var classWriter = new ClassWriter(0);
+        classNode.accept(classWriter);
+        return classWriter.toByteArray();
+    }
+
+    @Override
+    public int getPriority() {
+        return 0;
+    }
+}

--- a/src/main/java/com/cleanroommc/fugue/transformer/screenshot_viewer/ScreenshotViewerTransformer.java
+++ b/src/main/java/com/cleanroommc/fugue/transformer/screenshot_viewer/ScreenshotViewerTransformer.java
@@ -35,12 +35,12 @@ public class ScreenshotViewerTransformer implements IExplicitTransformer, Opcode
                 AbstractInsnNode node;
                 while (iterator.hasNext()) {
                     node = iterator.next();
-                    if (node.getOpcode() == Opcodes.IF_ICMPNE) {
-                        node.setOpcode(Opcodes.IFEQ);
-                        MethodInsnNode mn = (MethodInsnNode) node.prev.prev;
+                    if (node.getOpcode() instanceof JumpInsnNode jn) {
+                        jn.setOpcode(Opcodes.IFEQ);
+                        MethodInsnNode mn = (MethodInsnNode) node.getPrevious().getPrevious();
                         mn.name = "func_151468_f";
                         mn.desc = "()Z";
-                        method.instructions.remove(node.prev);
+                        method.instructions.remove(node.getPrevious());
                     } else if (node instanceof MethodInsnNode mn && "getEventKeyState".equals(mn.name)) {
                         iterator.set(new InsnNode(Opcodes.ICONST_1));
                     }

--- a/src/main/java/com/cleanroommc/fugue/transformer/screenshot_viewer/ScreenshotViewerTransformer.java
+++ b/src/main/java/com/cleanroommc/fugue/transformer/screenshot_viewer/ScreenshotViewerTransformer.java
@@ -35,7 +35,7 @@ public class ScreenshotViewerTransformer implements IExplicitTransformer, Opcode
                 AbstractInsnNode node;
                 while (iterator.hasNext()) {
                     node = iterator.next();
-                    if (node.getOpcode() instanceof JumpInsnNode jn) {
+                    if (node.getOpcode() == Opcodes.IF_ICMPNE && node instanceof JumpInsnNode jn) {
                         jn.setOpcode(Opcodes.IFEQ);
                         MethodInsnNode mn = (MethodInsnNode) node.getPrevious().getPrevious();
                         mn.name = "func_151468_f";

--- a/src/main/java/com/cleanroommc/fugue/transformer/screenshot_viewer/ScreenshotViewerTransformer.java
+++ b/src/main/java/com/cleanroommc/fugue/transformer/screenshot_viewer/ScreenshotViewerTransformer.java
@@ -18,8 +18,17 @@ public class ScreenshotViewerTransformer implements IExplicitTransformer, Opcode
         classReader.accept(classNode, 0);
 
         for (var method : classNode.methods) {
-            // Overwrite -- Actual Redirect
-            if ("onKeyInput".equals(method.name)) {
+            /**
+             * if (client.world != null 
+             * && client.currentScreen == null 
+             *  - && Keyboard.getEventKeyState() 
+             *  + openScreenshotsScreenKey.isPressed();
+             * && openScreenshotsScreenKey != null 
+             * && openScreenshotsScreenKey.getKeyCode() == Keyboard.getEventKey())
+             * 
+             * Check Not null ? Should not be null. Here is the minimal modification.
+             */
+            if ("onKeyInput".equals(method.name)) { 
                 for (AbstractInsnNode node : method.instructions) {
                     if (node instanceof MethodInsnNode mi) {
                         if ("getEventKeyState".equals(mi.name)) {


### PR DESCRIPTION
Fixes https://github.com/CleanroomMC/Cleanroom/issues/292
ScreenshotViewer key checking is incorrect. `Keyboard.getEventKeyState() && openScreenshotsScreenKey.getKeyCode() == Keyboard.getEventKey())`. It worked fine in Forge by accident, but in cleanroom, lwjgl switched to 3, the keyboard compatibility layer inner mechanism is different from the original mechanism, and the usability of this operation is no longer guaranteed.

We should not support wrong operations, we should fix wrong operations.

This patch is very rough, and has strong dependencies on module versions, such as `node.prev().prev()`, which may break in version updates. Of course, I don't think there will be any updates.