### PR TITLE
Add KubeJS (Nashorn) patch

### DIFF
--- a/src/main/java/com/cleanroommc/fugue/common/TransformerHelper.java
+++ b/src/main/java/com/cleanroommc/fugue/common/TransformerHelper.java
@@ -523,6 +523,24 @@ public class TransformerHelper {
                     "farseek.core.FarseekClassTransformer"
             );
         }
+        if (FugueConfig.modPatchConfig.enableKubeJS) {
+            TransformerDelegate.registerExplicitTransformer(
+                    new RemapTransformer(
+                            new String[] { "jdk/nashorn/api/scripting/" },
+                            new String[] { "org/openjdk/nashorn/api/scripting/" }
+                    ),
+                    "dev.latvian.kubejs.event.EventsJS",
+                    "dev.latvian.kubejs.fluid.FluidStackJS",
+                    "dev.latvian.kubejs.item.ingredient.IngredientJS",
+                    "dev.latvian.kubejs.item.ItemStackJS",
+                    "dev.latvian.kubejs.script.ScriptManager",
+                    "dev.latvian.kubejs.server.KubeJSServerEventHandler",
+                    "dev.latvian.kubejs.util.FunctionBinding",
+                    "dev.latvian.kubejs.util.JsonUtilsJS",
+                    "dev.latvian.kubejs.util.nbt.NBTBaseJS",
+                    "dev.latvian.kubejs.util.UtilsJS"
+            );
+        }
 
         //Common patches below
 
@@ -558,7 +576,24 @@ public class TransformerHelper {
         }
         if (FugueConfig.remapTargets.length > 0) {
             TransformerDelegate.registerExplicitTransformer(
-                    new RemapTransformer(),
+                    new RemapTransformer(
+                            new String[] {
+                                    "javax/xml/bind/",
+                                    "javax/xml/ws/",
+                                    "javax/ws/",
+                                    "javax/activation/",
+                                    "javax/soap/",
+                                    "javax/jws/"
+                            },
+                            new String[] {
+                                    "jakarta/xml/bind/",
+                                    "jakarta/xml/ws/",
+                                    "jakarta/ws/",
+                                    "jakarta/activation/",
+                                    "jakarta/soap/",
+                                    "jakarta/jws/"
+                            }
+                    ),
                     FugueConfig.remapTargets
             );
         }

--- a/src/main/java/com/cleanroommc/fugue/config/ModPatchConfig.java
+++ b/src/main/java/com/cleanroommc/fugue/config/ModPatchConfig.java
@@ -171,4 +171,6 @@ public class ModPatchConfig {
     public boolean enableNBTPeripheral = true;
     @Config.Name("Enable Farseek Patch")
     public boolean enableFarseek = true;
+    @Config.Name("Enable KubeJS Patch")
+    public boolean enableKubeJS = true;
 }

--- a/src/main/java/com/cleanroommc/fugue/transformer/universal/RemapTransformer.java
+++ b/src/main/java/com/cleanroommc/fugue/transformer/universal/RemapTransformer.java
@@ -9,17 +9,22 @@ import org.objectweb.asm.commons.Remapper;
 import top.outlands.foundation.IExplicitTransformer;
 
 public class RemapTransformer implements IExplicitTransformer {
+    private final String[] fromPrefixes;
+    private final String[] toPrefixes;
 
+    public RemapTransformer(String[] fromPrefixes, String[] toPrefixes) {
+        this.fromPrefixes = fromPrefixes;
+        this.toPrefixes = toPrefixes;
+    }
 
     @Override
     public byte[] transform( byte[] bytes) {
-
         if (bytes == null) {
             return null;
         }
         ClassReader reader = new ClassReader(bytes);
         ClassWriter writer = new ClassWriter(0);
-        ClassVisitor visitor = new ClassRemapper(writer, new RemapTransformer.JavaxRemapper());
+        ClassVisitor visitor = new ClassRemapper(writer, new PrefixRemapper(fromPrefixes, toPrefixes));
         try {
             reader.accept(visitor, ClassReader.EXPAND_FRAMES);
         } catch (Exception e) {
@@ -29,10 +34,14 @@ public class RemapTransformer implements IExplicitTransformer {
         return writer.toByteArray();
     }
 
-    static class JavaxRemapper extends Remapper {
-        final String[] fromPrefixes = new String[] { "javax/xml/bind/", "javax/xml/ws/", "javax/ws/", "javax/activation/", "javax/soap/", "javax/jws/"};
+    static class PrefixRemapper extends Remapper {
+        private final String[] fromPrefixes;
+        private final String[] toPrefixes;
 
-        final String[] toPrefixes = new String[] { "jakarta/xml/bind/", "jakarta/xml/ws/", "jakarta/ws/", "jakarta/activation/", "jakarta/soap/", "jakarta/jws/"};
+        public PrefixRemapper(String[] fromPrefixes, String[] toPrefixes) {
+            this.fromPrefixes = fromPrefixes;
+            this.toPrefixes = toPrefixes;
+        }
 
         @Override
         public String map(String typeName) {


### PR DESCRIPTION
Fixes CleanroomMC/Cleanroom#327

I extended the already existing `RemapTransformer` a little bit to allow remapping package names from `jdk.nashorn.api.scripting` to `org.openjdk.nashorn.api.scripting`.

This allows KubeJS to work under CleanroomMC, which previously crashed at startup.

Let me know if there is anything to change, I tried to not modify too much.