### PR TITLE
Patch celeritas

### DIFF
--- a/src/main/java/com/cleanroommc/fugue/common/TransformerHelper.java
+++ b/src/main/java/com/cleanroommc/fugue/common/TransformerHelper.java
@@ -10,6 +10,7 @@ import com.cleanroommc.fugue.transformer.betterhurttimer.DamageSpecialArmorMixin
 import com.cleanroommc.fugue.transformer.betterportals.MixinEntityRendererTransformer;
 import com.cleanroommc.fugue.transformer.betterportals.ExtensionKtTransformer;
 import com.cleanroommc.fugue.transformer.calculator.GuiInfoCalculatorTransformer;
+import com.cleanroommc.fugue.transformer.celeritas.CeleritasVintageMixinPluginTransformer;
 import com.cleanroommc.fugue.transformer.codechickenlib.ClassHierarchyManagerTransformer;
 import com.cleanroommc.fugue.transformer.colytra.EntityLivingBaseTransformer;
 import com.cleanroommc.fugue.transformer.corpse.MessageOpenHistoryTransformer;
@@ -544,6 +545,12 @@ public class TransformerHelper {
             TransformerDelegate.registerExplicitTransformer(
                     new KubeJSTransformer(),
                     "dev.latvian.kubejs.KubeJS"
+            );
+        }
+        if (FugueConfig.modPatchConfig.enableCeleritas) {
+            TransformerDelegate.registerExplicitTransformer(
+                    new CeleritasVintageMixinPluginTransformer(),
+                    "org.taumc.celeritas.mixin.CeleritasVintageMixinPlugin"
             );
         }
 

--- a/src/main/java/com/cleanroommc/fugue/config/ModPatchConfig.java
+++ b/src/main/java/com/cleanroommc/fugue/config/ModPatchConfig.java
@@ -173,4 +173,6 @@ public class ModPatchConfig {
     public boolean enableFarseek = true;
     @Config.Name("Enable KubeJS Patch")
     public boolean enableKubeJS = true;
+    @Config.Name("Enable Celeritas Patch")
+    public boolean enableCeleritas = true;
 }

--- a/src/main/java/com/cleanroommc/fugue/transformer/celeritas/CeleritasVintageMixinPluginTransformer.java
+++ b/src/main/java/com/cleanroommc/fugue/transformer/celeritas/CeleritasVintageMixinPluginTransformer.java
@@ -1,0 +1,43 @@
+package com.cleanroommc.fugue.transformer.celeritas;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.*;
+import top.outlands.foundation.IExplicitTransformer;
+
+public class CeleritasVintageMixinPluginTransformer implements IExplicitTransformer {
+
+    @Override
+    public byte[] transform(byte[] bytes) {
+        ClassNode classNode = new ClassNode();
+        ClassReader classReader = new ClassReader(bytes);
+        classReader.accept(classNode, 0);
+        if (classNode.methods != null) {
+            for (MethodNode methodNode : classNode.methods) {
+                if (methodNode.name.equals("onLoad")) {
+                    InsnList instructions = methodNode.instructions;
+                    if (instructions != null) {
+                        for (AbstractInsnNode insnNode : instructions) {
+                            if (insnNode instanceof MethodInsnNode methodInsnNode) {
+                                if (methodInsnNode.getOpcode() == Opcodes.INVOKESTATIC) {
+                                    if (
+                                            methodInsnNode.owner.equals("com/gtnewhorizons/retrofuturabootstrap/SharedConfig") &&
+                                            methodInsnNode.name.equals("getRfbTransformers") &&
+                                            methodInsnNode.desc.equals("()Ljava/util/List;")
+                                    ) {
+                                        instructions.insertBefore(methodInsnNode, new InsnNode(Opcodes.RETURN));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        ClassWriter classWriter = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+
+        classNode.accept(classWriter);
+        return classWriter.toByteArray();
+    }
+}


### PR DESCRIPTION
Patches [Celeritas](https://git.taumc.org/embeddedt/celeritas) by skipping the call for non-existing methods on crl

*Note*: Do not patch the `toURI` methods in `CeleritasVintageMixinPlugin#getMixins`, it's intended.