### PR TITLE
Add FugueCrashTag

### DIFF
--- a/src/main/java/com/cleanroommc/fugue/common/Fugue.java
+++ b/src/main/java/com/cleanroommc/fugue/common/Fugue.java
@@ -23,7 +23,7 @@ import java.util.Map;
 )
 public class Fugue {
     
-    public static Logger LOGGER = LogManager.getLogger(Reference.MOD_NAME);
+    public static Logger LOGGER = FugueLoadingPlugin.LOGGER;
 
     public static boolean isModNewerThan(String modid, String version) {
         var mod = Loader.instance().getIndexedModList().get(modid);

--- a/src/main/java/com/cleanroommc/fugue/common/Fugue.java
+++ b/src/main/java/com/cleanroommc/fugue/common/Fugue.java
@@ -36,7 +36,7 @@ public class Fugue {
     public static Fugue _instance;
 
     public Fugue() {
-	FMLCommonHandler.instance().registerCrashCallable(new FugueCrashTag());`
+	FMLCommonHandler.instance().registerCrashCallable(new FugueCrashTag());
     }
 
     @NetworkCheckHandler

--- a/src/main/java/com/cleanroommc/fugue/common/Fugue.java
+++ b/src/main/java/com/cleanroommc/fugue/common/Fugue.java
@@ -1,8 +1,6 @@
 package com.cleanroommc.fugue.common;
 
 import com.cleanroommc.fugue.Reference;
-import net.minecraftforge.fml.common.FMLCommonHandler;
-import net.minecraftforge.fml.common.ICrashCallable;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.Instance;
@@ -36,23 +34,11 @@ public class Fugue {
     public static Fugue _instance;
 
     public Fugue() {
-	FMLCommonHandler.instance().registerCrashCallable(new FugueCrashTag());
     }
 
     @NetworkCheckHandler
     public boolean checker(Map<String, String> mods, Side side) {
         return true;
-    }
-
-    public static class FugueCrashTag implements ICrashCallable {
-	@Override
-        public String call() {
-            return Reference.MOD_VERSION;
-        }
-        @Override
-        public String getLabel() {
-            return "Fugue Version";
-        }
     }
 
 }

--- a/src/main/java/com/cleanroommc/fugue/common/Fugue.java
+++ b/src/main/java/com/cleanroommc/fugue/common/Fugue.java
@@ -1,6 +1,7 @@
 package com.cleanroommc.fugue.common;
 
 import com.cleanroommc.fugue.Reference;
+import net.minecraftforge.fml.common.ICrashCallable;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.Instance;
@@ -39,6 +40,17 @@ public class Fugue {
     @NetworkCheckHandler
     public boolean checker(Map<String, String> mods, Side side) {
         return true;
+    }
+
+    public static class FugueCrashTag implements ICrashCallable {
+	@Override
+        public String call() {
+            return Reference.MOD_VERSION;
+        }
+        @Override
+        public String getLabel() {
+            return "Fugue Version";
+        }
     }
 
 }

--- a/src/main/java/com/cleanroommc/fugue/common/Fugue.java
+++ b/src/main/java/com/cleanroommc/fugue/common/Fugue.java
@@ -1,6 +1,7 @@
 package com.cleanroommc.fugue.common;
 
 import com.cleanroommc.fugue.Reference;
+import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.ICrashCallable;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod;
@@ -31,10 +32,11 @@ public class Fugue {
         return new ComparableVersion(mod.getVersion()).compareTo(new ComparableVersion(version)) > 0;
     }
 	
-	@Instance(Reference.MOD_ID)
-	public static Fugue _instance;
-    public Fugue() {
+    @Instance(Reference.MOD_ID)
+    public static Fugue _instance;
 
+    public Fugue() {
+	FMLCommonHandler.instance().registerCrashCallable(new FugueCrashTag());`
     }
 
     @NetworkCheckHandler

--- a/src/main/java/com/cleanroommc/fugue/common/FugueLoadingPlugin.java
+++ b/src/main/java/com/cleanroommc/fugue/common/FugueLoadingPlugin.java
@@ -4,12 +4,13 @@ import com.cleanroommc.fugue.Reference;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.ICrashCallable;
 import com.cleanroommc.fugue.config.FugueConfig;
-import com.cleanroommc.fugue.transformer.tfcmedical.CommonRegistrar$Transformer;
 import net.minecraft.launchwrapper.Launch;
 import net.minecraftforge.common.config.ConfigManager;
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin;
 import net.minecraftforge.fml.relauncher.IFMLCallHook;
 import top.outlands.foundation.TransformerDelegate;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -19,7 +20,10 @@ import java.util.Map;
 @IFMLLoadingPlugin.Name("Fugue")
 public class FugueLoadingPlugin implements IFMLLoadingPlugin {
 
+    public static final Logger LOGGER = LogManager.getLogger(Reference.MOD_NAME);
+
     static {
+        LOGGER.info("Fugue Version: " + Reference.MOD_VERSION);
         Launch.classLoader.addTransformerExclusion("com.cleanroommc.fugue.common.");
         Launch.classLoader.addTransformerExclusion("com.cleanroommc.fugue.helper.");
         for (var prefix : FugueConfig.extraTransformExclusions) {
@@ -32,36 +36,10 @@ public class FugueLoadingPlugin implements IFMLLoadingPlugin {
         TransformerHelper.registerTransformers();
     }
 
-    @Nullable
-    @Override
-    public String getSetupClass() {
-        return "com.cleanroommc.fugue.common.FugueLoadingPlugin$Setup";
-    }
-
     public static void injectCascadingTweak(String tweakClassName)
     {
         @SuppressWarnings("unchecked")
         List<String> tweakClasses = (List<String>) Launch.blackboard.get("TweakClasses");
         tweakClasses.add(tweakClassName);
-    }
-
-    public static class Setup implements IFMLCallHook {
-        public void injectData(Map<String,Object> data) {}
-
-        public Void call() {
-            FMLCommonHandler.instance().registerCrashCallable(new FugueCrashTag());
-            return null;
-        }
-
-        public static class FugueCrashTag implements ICrashCallable {
-	        @Override
-            public String call() {
-                return Reference.MOD_VERSION;
-            }
-            @Override
-            public String getLabel() {
-                return "Fugue Version";
-            }
-        }
     }
 }

--- a/src/main/java/com/cleanroommc/fugue/common/FugueLoadingPlugin.java
+++ b/src/main/java/com/cleanroommc/fugue/common/FugueLoadingPlugin.java
@@ -1,10 +1,14 @@
 package com.cleanroommc.fugue.common;
 
+import com.cleanroommc.fugue.Reference;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.common.ICrashCallable;
 import com.cleanroommc.fugue.config.FugueConfig;
 import com.cleanroommc.fugue.transformer.tfcmedical.CommonRegistrar$Transformer;
 import net.minecraft.launchwrapper.Launch;
 import net.minecraftforge.common.config.ConfigManager;
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin;
+import net.minecraftforge.fml.relauncher.IFMLCallHook;
 import top.outlands.foundation.TransformerDelegate;
 
 import javax.annotation.Nullable;
@@ -28,38 +32,10 @@ public class FugueLoadingPlugin implements IFMLLoadingPlugin {
         TransformerHelper.registerTransformers();
     }
 
-    
-    @Override
-    public String[] getASMTransformerClass() {
-        if (FugueConfig.modPatchConfig.enableTFCMedical) {
-            TransformerDelegate.registerExplicitTransformer(
-                    new CommonRegistrar$Transformer(),
-                    "com.lumintorious.tfcmedicinal.CommonRegistrar$",
-                    "com.lumintorious.tfcmedicinal.object.mpestle.MPestleRecipe$",
-                    "com.lumintorious.tfcmedicinal.object.heater.HeaterRecipe");
-        }
-        return new String[0];
-    }
-
-    @Override
-    public String getModContainerClass() {
-        return null;
-    }
-
     @Nullable
     @Override
     public String getSetupClass() {
-        return null;
-    }
-
-    @Override
-    public void injectData(Map<String, Object> map) {
-
-    }
-
-    @Override
-    public String getAccessTransformerClass() {
-        return null;
+        return "com.cleanroommc.fugue.common.FugueLoadingPlugin$Setup";
     }
 
     public static void injectCascadingTweak(String tweakClassName)
@@ -67,5 +43,25 @@ public class FugueLoadingPlugin implements IFMLLoadingPlugin {
         @SuppressWarnings("unchecked")
         List<String> tweakClasses = (List<String>) Launch.blackboard.get("TweakClasses");
         tweakClasses.add(tweakClassName);
+    }
+
+    public static class Setup implements IFMLCallHook {
+        public void injectData(Map<String,Object> data) {}
+
+        public Void call() {
+            FMLCommonHandler.instance().registerCrashCallable(new FugueCrashTag());
+            return null;
+        }
+
+        public static class FugueCrashTag implements ICrashCallable {
+	        @Override
+            public String call() {
+                return Reference.MOD_VERSION;
+            }
+            @Override
+            public String getLabel() {
+                return "Fugue Version";
+            }
+        }
     }
 }

--- a/src/main/java/com/cleanroommc/fugue/common/TransformerHelper.java
+++ b/src/main/java/com/cleanroommc/fugue/common/TransformerHelper.java
@@ -169,6 +169,13 @@ public class TransformerHelper {
                     "austeretony.enchcontrol.common.core.EnumInputClass"
             );
         }
+        if (FugueConfig.modPatchConfig.enableTFCMedical) {
+            TransformerDelegate.registerExplicitTransformer(
+                    new CommonRegistrar$Transformer(),
+                    "com.lumintorious.tfcmedicinal.CommonRegistrar$",
+                    "com.lumintorious.tfcmedicinal.object.mpestle.MPestleRecipe$",
+                    "com.lumintorious.tfcmedicinal.object.heater.HeaterRecipe");
+        }
         if (FugueConfig.modPatchConfig.enableTheASM) {
             TransformerDelegate.registerExplicitTransformer(
                     new LoliReflectorTransformer(),

--- a/src/main/java/com/cleanroommc/fugue/common/TransformerHelper.java
+++ b/src/main/java/com/cleanroommc/fugue/common/TransformerHelper.java
@@ -66,6 +66,7 @@ import com.cleanroommc.fugue.transformer.subaquatic.PluginEntityTransformer;
 import com.cleanroommc.fugue.transformer.subaquatic.SubaquaticIMTransformer;
 import com.cleanroommc.fugue.transformer.survivalinc.ForgeASMInjectorTransformer;
 import com.cleanroommc.fugue.transformer.techgun.TechgunsASMTransformerTransformer;
+import com.cleanroommc.fugue.transformer.tfcmedical.CommonRegistrar$Transformer;
 import com.cleanroommc.fugue.transformer.universal.RemoveMixinInitFromCotrTransformer;
 import com.cleanroommc.fugue.transformer.tickcentral.*;
 import com.cleanroommc.fugue.transformer.universal.*;


### PR DESCRIPTION
add fugue crash tag.
It is convenient to directly observe the fugue version or whether fugue is installed.
`ICrashCallable` will be collected by asmDataTable and registered for FMLModContainer.