### PR TITLE
Only Redirect the constructor to CleanroomScriptEngineManager

### DIFF
--- a/src/main/java/com/cleanroommc/fugue/transformer/universal/ScriptEngineTransformer.java
+++ b/src/main/java/com/cleanroommc/fugue/transformer/universal/ScriptEngineTransformer.java
@@ -12,9 +12,9 @@ public class ScriptEngineTransformer implements IExplicitTransformer {
     @Override
     public byte[] transform(byte[] bytes) {
         ClassReader reader = new ClassReader(bytes);
-        ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+        ClassWriter writer = new ClassWriter(0);
         CV cv = new CV(writer);
-        reader.accept(cv, ClassReader.EXPAND_FRAMES);
+        reader.accept(cv, 0);
         return writer.toByteArray();
     }
 
@@ -63,7 +63,7 @@ public class ScriptEngineTransformer implements IExplicitTransformer {
                 final String descriptor,
                 final boolean isInterface) {
             if (mv != null) {
-                if (owner.equals("javax/script/ScriptEngineManager")) {
+                if ("javax/script/ScriptEngineManager".equals(owner) && "<init>".equals(name)) {
                     mv.visitMethodInsn(
                             opcode,
                             "com/cleanroommc/loader/scripting/CleanroomScriptEngineManager",


### PR DESCRIPTION
fix https://github.com/CleanroomMC/Cleanroom/issues/485

<img width="837" height="507" alt="image" src="https://github.com/user-attachments/assets/eb708fa5-8ffc-49a5-ac9b-bd58aff826cb" />

Need we remove the realms for the mod screen?
