### PR TITLE
patch `FinalFieldHelper` from HammerCore

### DIFF
--- a/src/main/java/com/cleanroommc/fugue/mixin/hammercore/FinalFieldHelperMixin.java
+++ b/src/main/java/com/cleanroommc/fugue/mixin/hammercore/FinalFieldHelperMixin.java
@@ -1,0 +1,34 @@
+package com.cleanroommc.fugue.mixin.hammercore;
+
+import com.zeitheron.hammercore.utils.FinalFieldHelper;
+import com.zeitheron.hammercore.utils.ReflectionUtil;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.lang.reflect.Field;
+
+/**
+ * This class is deprecated but somehow still being used by other mods. We redirect everything to {@link com.zeitheron.hammercore.utils.ReflectionUtil} because {@code ReflectionUtil} is patched
+ *
+ * @author ZZZank
+ */
+@Mixin(value = FinalFieldHelper.class, remap = false)
+public abstract class FinalFieldHelperMixin {
+
+    @Inject(method = "setStaticFinalField(Ljava/lang/Class;Ljava/lang/String;Ljava/lang/Object;)Z", at = @At("HEAD"), cancellable = true)
+    private static void setFinalFieldStaticInClass(Class<?> cls, String name, Object val, CallbackInfoReturnable<Boolean> cir) {
+        cir.setReturnValue(ReflectionUtil.setStaticFinalField(cls, name, val));
+    }
+
+    @Inject(method = "setStaticFinalField(Ljava/lang/reflect/Field;Ljava/lang/Object;)Z", at = @At("HEAD"), cancellable = true)
+    private static void setFinalFieldStatic(Field f, Object val, CallbackInfoReturnable<Boolean> cir) {
+        cir.setReturnValue(ReflectionUtil.setStaticFinalField(f, val));
+    }
+
+    @Inject(method = "setFinalField", at = @At("HEAD"), cancellable = true)
+    private static void setFinalField(Field f, Object instance, Object thing, CallbackInfoReturnable<Boolean> cir) throws ReflectiveOperationException {
+        cir.setReturnValue(ReflectionUtil.setFinalField(f, instance, thing));
+    }
+}

--- a/src/main/resources/fugue.mixin.mod.json
+++ b/src/main/resources/fugue.mixin.mod.json
@@ -15,7 +15,9 @@
     "dissolution.PossessableEntityFactoryMixin",
     "extrautils2.FieldSetterMixin",
     "funkylocomotion.WrenchFactoryMixin",
+    "glibysphysics.GManMixin",
     "gregtech.GTRecipeInputCacheMixin",
+    "hammercore.FinalFieldHelperMixin",
     "hammercore.ReflectionUtilMixin",
     "howlingmoon.WerewolfCapabilityMixin",
     "mage.ColorspacesMixin",
@@ -32,8 +34,7 @@
     "unilib.FileUtilsMixin",
     "waterpower.ClassEngineMixin",
     "xaeroplus.ChunkHighlightSavingCacheMixin",
-    "xaeroplus.XaeroPlusSettingsReflectionHaxMixin",
-    "glibysphysics.GManMixin"
+    "xaeroplus.XaeroPlusSettingsReflectionHaxMixin"
   ],
   "client": [
     "custommainmenu.SlideshowMixin",


### PR DESCRIPTION
Related crash report: https://mclo.gs/M8SKTTT

```
Caused by: java.lang.NoSuchMethodException: sun.reflect.ReflectionFactory.newFieldAccessor(java.lang.reflect.Field,boolean)
   at java.lang.Class.getDeclaredMethod(Class.java:2907)
   at com.zeitheron.hammercore.utils.FinalFieldHelper.makeWritable(FinalFieldHelper.java:65)
   at com.zeitheron.hammercore.utils.FinalFieldHelper.setFinalField(FinalFieldHelper.java:50)
   at com.zeitheron.visuals.compat.base.VisualsCompat.createProxy(VisualsCompat.java:28)
```